### PR TITLE
Glue mlm

### DIFF
--- a/conf_mlm/mlm.yaml
+++ b/conf_mlm/mlm.yaml
@@ -1,0 +1,42 @@
+runs: 1
+debug: true
+train:
+  epochs: 10
+  lr: 2.0e-05
+  batch_size: 16
+  fraction: 1.0
+  seq_len: 512
+  mark_only_rosa_or_lora_as_trainable: true
+  optimizer:
+    name: adamw
+    params:
+      betas: [0.9, 0.98]
+      eps: 1.0e-06
+      weight_decay: 0.1
+  scheduler:
+    name: linear
+    warmup_ratio: 0.1
+    params: {}
+model:
+  name: roberta-base
+  cache: /home/mila/a/aristides.milios/scratch/hf_cache
+fnmodel:
+  name: none
+  params:
+    rank: 0.01
+    level: epoch
+    sample_method: random
+    collapse_fixed: true
+logging:
+  print_freq: 100
+  input_size: [8, 512]
+  memory_info: true
+output:
+  path: /home/mila/a/aristides.milios/scratch/rosa/runs
+dataset:
+  name: glue
+  task_name: cola
+  cache: /home/mila/a/aristides.milios/scratch/hf_cache
+eval:
+  batch_size: 16
+  experiment: runs/glue/cola/roberta-base_factorized_0.01_epoch_random_1.0_5e-05_5_1

--- a/conf_mlm/model/ft.yaml
+++ b/conf_mlm/model/ft.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+train:
+  epochs: 10
+fnmodel:
+  name: none

--- a/conf_mlm/model/lora.yaml
+++ b/conf_mlm/model/lora.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+
+train:
+  epochs: 30
+  lr: 2.0e-04
+fnmodel:
+  name: lora

--- a/conf_mlm/model/rosa.yaml
+++ b/conf_mlm/model/rosa.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+
+train:
+  epochs: 30
+  lr: 2.0e-04
+fnmodel:
+  name: rosa

--- a/conf_mlm/task/cola.yaml
+++ b/conf_mlm/task/cola.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: cola

--- a/conf_mlm/task/mnli.yaml
+++ b/conf_mlm/task/mnli.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: mnli

--- a/conf_mlm/task/mrpc.yaml
+++ b/conf_mlm/task/mrpc.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: mrpc

--- a/conf_mlm/task/qnli.yaml
+++ b/conf_mlm/task/qnli.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: qnli

--- a/conf_mlm/task/qqp.yaml
+++ b/conf_mlm/task/qqp.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: qqp

--- a/conf_mlm/task/rte.yaml
+++ b/conf_mlm/task/rte.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: rte

--- a/conf_mlm/task/sst2.yaml
+++ b/conf_mlm/task/sst2.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: sst2

--- a/conf_mlm/task/stsb.yaml
+++ b/conf_mlm/task/stsb.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: stsb

--- a/conf_mlm/task/wnli.yaml
+++ b/conf_mlm/task/wnli.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+
+dataset:
+  task_name: wnli

--- a/configs_mlm.yaml
+++ b/configs_mlm.yaml
@@ -1,24 +1,25 @@
 runs: 1
 debug: True
 train:
-  epochs: 5
-  lr: 5e-5
-  batch_size: 10
+  epochs: 10
+  lr: 2e-5
+  batch_size: 16
   fraction: 1.0 # ratio of the training set to use
   seq_len: 512
   mark_only_rosa_or_lora_as_trainable: True
   optimizer:
     name: adamw # adam, adamw sgd
     params:
-      momentum: 0.9
-      weight_decay: 0.01
+      betas: [0.9, 0.98]
+      eps: 1e-6
+      weight_decay: 0.1
   scheduler:
     name: linear # linear, cosine, constant, none
-    params:
-      num_warmup_steps: 500
+    warmup_ratio: 0.1
+    params: {}
 model:
   name: roberta-base  # or microsoft/deberta-v2-xxlarge eventually
-  cache: /home/mila/m/marawan.gamal/scratch/hf_cache
+  cache: /home/mila/a/aristides.milios/scratch/hf_cache
 fnmodel:
   name: none # rosa, lora, none
   params:
@@ -28,14 +29,14 @@ fnmodel:
     collapse_fixed: True # for factorized only. collapse fixed parameters
 logging:
   print_freq: 100
-  input_size: [8, 512]  # used to compute latency [batch_size, seq_len]
+  input_size: [8,512]  # used to compute latency [batch_size, seq_len]
   memory_info: True  # record memory usage
 output:
-  path: /home/mila/m/marawan.gamal/scratch/rosa/runs
+  path: /home/mila/a/aristides.milios/scratch/rosa/runs
 dataset:
   name: glue
-  task_name: mnli
-  cache: /home/mila/m/marawan.gamal/scratch/hf_cache
+  task_name: cola
+  cache: /home/mila/a/aristides.milios/scratch/hf_cache
 eval:
-  batch_size: 8
+  batch_size: 16
   experiment: runs/glue/cola/roberta-base_factorized_0.01_epoch_random_1.0_5e-05_5_1

--- a/train_mlm.py
+++ b/train_mlm.py
@@ -411,7 +411,7 @@ def train(args, cmodel, optimizer, lr_scheduler, train_dataloader, valid_dataloa
         logging.info("\nEND of Epoch\n=========\n")
 
 
-@hydra.main(version_base=None, config_path="./", config_name="configs_mlm")
+@hydra.main(version_base=None, config_path="./conf_mlm", config_name="mlm")
 def main(cfg: DictConfig):
     # Experiment tracking and logging
     args = OmegaConf.to_container(cfg, resolve=True)

--- a/utils.py
+++ b/utils.py
@@ -282,9 +282,10 @@ def preprocess_function_mlm(examples, tokenizer, task_name="cola", max_length=51
     # tokenize the texts, passing two arguments to the tokenizer
     # if the task has two inputs. otherwise just one
     if text_keys[1] is not None:
-        output = tokenizer(examples[text_keys[0]], examples[text_keys[1]], max_length=max_length, truncation=True)
+        # pad to max length
+        output = tokenizer(examples[text_keys[0]], examples[text_keys[1]], max_length=max_length, truncation=True, padding="max_length")
     else:
-        output = tokenizer(examples[text_keys[0]], max_length=max_length, truncation=True)
+        output = tokenizer(examples[text_keys[0]], max_length=max_length, truncation=True, padding="max_length")
     
     # output["labels"] is just "label" for mlm task
     output["labels"] = examples["label"]


### PR DESCRIPTION
Hey!

Main changes are:

=> new config structure so we can override specific parameters for specific glue tasks via Hydra
=> warmup_ratio parameter so we can specify a ratio instead of having to give a specific number of warmup_steps
=> datacollator no longer handles padding, that's done within the tokenizer and is padded to max_length (this is what most existing works on glue do)
=> output is now saved to `runs/glue/task_name` instead of just `runs/glue` (via dataset name only as before, now there's one more level of nesting to separate tasks)